### PR TITLE
Using the getters and setters instead of property access

### DIFF
--- a/samples/2017-2-kilimanjaro/ExamplePublishPush@1.0.0/SuiteScript/ExamplePublishPushThing.js
+++ b/samples/2017-2-kilimanjaro/ExamplePublishPush@1.0.0/SuiteScript/ExamplePublishPushThing.js
@@ -12,9 +12,10 @@ define('ExamplePublishPushThing'
 {
   'use strict';
 
-  Configuration.publish = Configuration.publish || [];
+  Configuration.set('publish', Configuration.get('publish') || []);
+  var pub = Configuration.get('publish');
 
-  Configuration.publish.push({
+  pub.push({
     key: 'ExamplePublishPush'
   , model: 'ExamplePublishPush.Model'
   , call: 'setSomeValueOrSomething'


### PR DESCRIPTION
For some reason this works. Hitting `Configuration.publish` directly results in the object never making to the front-end.